### PR TITLE
Fix hash conditions documentation [ci skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -513,8 +513,6 @@ Article.where(author: author)
 Author.joins(:articles).where(articles: { author: author })
 ```
 
-NOTE: The values cannot be symbols. For example, you cannot do `Client.where(status: :active)`.
-
 #### Range Conditions
 
 ```ruby


### PR DESCRIPTION
The guides state that symbols cannot be used as hash values, which is untrue. 

For example in the [Rails enum documentation](http://api.rubyonrails.org/v5.1.1/classes/ActiveRecord/Enum.html) symbols are being used. `Conversation.where.not(status: :active)`

